### PR TITLE
Throw exception on any response except 200

### DIFF
--- a/classes/class-wp-sailthru-client.php
+++ b/classes/class-wp-sailthru-client.php
@@ -56,8 +56,11 @@ class WP_Sailthru_Client extends Sailthru_Client {
                 throw new Sailthru_Client_Exception("Bad response received from $url: " . $reply->get_error_message() );
             } else {
 
-                if( wp_remote_retrieve_response_code( $reply ) == 200 ) {
-                   return $reply['body']; 
+                if( wp_remote_retrieve_response_code( $reply ) !== 200 ) {
+                    throw new Sailthru_Client_Exception( $reply['body'] );
+                }
+                else {
+                    return $reply['body'];
                 }
                 
             }


### PR DESCRIPTION
This file should throw an exception if the Sailthru server responds back with any HTTP code besides 200.  As it stands, if there is an error with, say, a 401 error code, this file will not throw an exception and not return any useful error message from the server.
